### PR TITLE
Update data_dir argument to use new `dataset` dir

### DIFF
--- a/experiments/bert/run_bert_baseline.sh
+++ b/experiments/bert/run_bert_baseline.sh
@@ -5,7 +5,7 @@ python experiments/bert/run_classifier.py \
   --do_train \
   --do_eval \
   --do_lower_case \
-  --data_dir data \
+  --data_dir dataset \
   --bert_model bert-base-uncased \
   --max_seq_length 128 \
   --train_batch_size 32 \


### PR DESCRIPTION
Similar to Issue #6, the `data-dir` argument in `run_bert_baseline.sh` used `data` instead of the updated `dataset`. This resulted in a `FileNotFoundError` when trying to run the bash script. This PR updates the argument to the proper `dataset` directory name.